### PR TITLE
feat: implement fund lock mechanism (2-Phase Commit)

### DIFF
--- a/src/omniclaw/ledger/lock.py
+++ b/src/omniclaw/ledger/lock.py
@@ -1,0 +1,89 @@
+"""
+Fund Lock Service (2-Phase Commit).
+
+Provides a locking mechanism to prevent race conditions during payment execution.
+Ensures that multiple agents sharing the same wallet do not double-spend funds.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from omniclaw.storage.base import StorageBackend
+
+logger = logging.getLogger(__name__)
+
+
+class FundLockService:
+    """
+    Service for managing fund locks (mutexes).
+
+    Implements a distributed lock pattern using the storage backend.
+    """
+
+    def __init__(self, storage: StorageBackend) -> None:
+        """
+        Initialize lock service.
+
+        Args:
+            storage: Storage backend (Redis/Memory)
+        """
+        self._storage = storage
+
+    async def acquire(
+        self,
+        wallet_id: str,
+        amount: Decimal,
+        ttl: int = 30,
+        retry_count: int = 3,
+        retry_delay: float = 0.5,
+    ) -> str | None:
+        """
+        Acquire a lock for a wallet.
+
+        This is a coarse-grained lock that serializes access to the wallet
+        for the duration of the transaction setup (Phase 1).
+
+        Args:
+            wallet_id: Wallet ID to lock
+            amount: Amount being spent (for logging/future optimization)
+            ttl: Lock time-to-live in seconds
+            retry_count: Number of retries if lock is held
+            retry_delay: Delay between retries
+
+        Returns:
+            lock_id (str) if successful, None if failed
+        """
+        lock_key = f"lock:wallet:{wallet_id}"
+        
+        for i in range(retry_count + 1):
+            if await self._storage.acquire_lock(lock_key, ttl):
+                logger.debug(f"Acquired lock for wallet {wallet_id}")
+                return lock_key  # In this simple implementation, key is the ID
+            
+            if i < retry_count:
+                logger.debug(f"Wallet {wallet_id} locked, retrying in {retry_delay}s...")
+                await asyncio.sleep(retry_delay)
+        
+        logger.warning(f"Failed to acquire lock for wallet {wallet_id} after {retry_count} retries")
+        return None
+
+    async def release(self, lock_key: str) -> bool:
+        """
+        Release a previously acquired lock.
+
+        Args:
+            lock_key: The key returned by acquire()
+
+        Returns:
+            True if released, False if not found
+        """
+        result = await self._storage.release_lock(lock_key)
+        if result:
+            logger.debug(f"Released lock {lock_key}")
+        return result

--- a/src/omniclaw/resilience/__init__.py
+++ b/src/omniclaw/resilience/__init__.py
@@ -5,12 +5,12 @@ Provides Distributed Circuit Breakers and Retry mechanisms.
 """
 
 from .circuit import CircuitBreaker, CircuitOpenError, CircuitState
-from .retry import retry_policy, retry_interactive
+from .retry import retry_policy, execute_with_retry
 
 __all__ = [
     "CircuitBreaker",
     "CircuitOpenError",
     "CircuitState",
     "retry_policy",
-    "retry_interactive",
+    "execute_with_retry",
 ]

--- a/src/omniclaw/storage/base.py
+++ b/src/omniclaw/storage/base.py
@@ -164,6 +164,40 @@ class StorageBackend(ABC):
         """
         ...
 
+    @abstractmethod
+    async def acquire_lock(
+        self,
+        key: str,
+        ttl: int = 30,
+    ) -> bool:
+        """
+        Acquire a distributed lock.
+
+        Args:
+            key: Lock key (unique resource identifier)
+            ttl: Time-to-live in seconds (lock auto-release)
+
+        Returns:
+            True if lock acquired, False if already held
+        """
+        ...
+
+    @abstractmethod
+    async def release_lock(
+        self,
+        key: str,
+    ) -> bool:
+        """
+        Release a distributed lock.
+
+        Args:
+            key: Lock key
+
+        Returns:
+            True if lock released, False if not found
+        """
+        ...
+
     async def health_check(self) -> bool:
         """
         Check if storage is healthy and connected.


### PR DESCRIPTION
## Description
Implements the 'Fund Lock' mechanism (2-Phase Commit) to prevent race conditions during direct payments.
This ensures that when an agent initiates a payment, the wallet is 'locked' (mutex) before execution, preventing double-spending if multiple agents share the same wallet.

## Changes
- **New Service:**  in .
- **Storage Update:** Added  /  to  interface.
- **Implementations:** Added Redis (SET NX) and In-Memory implementations.
- **Client Update:** Integrated  into .
- **Resilience Fix:** Fixed import error in .

## How it works
1. **Acquire:** Before executing a payment, the client attempts to acquire a distributed lock for the wallet ().
2. **Execute:** If acquired, the payment proceeds (checking balance, executing via Circle API).
3. **Release:** The lock is released immediately after success/failure (or expires via TTL if the process crashes).

## Testing
- Verified with local test script using .
- Confirmed lock acquisition, rejection on retry, and release.