### PR TITLE
Document local economy and business compute examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ export OMNICLAW_CLI_HUMAN=1
 
 Note: `omniclaw` and `omniclaw-cli` point to the same CLI.
 
+## Examples
+
+- `examples/local-economy/README.md` — canonical local buyer/seller flow
+- `examples/business-compute/README.md` — business-facing paid compute and paid PDF seller using OmniClaw directly in a web app
+
 ---
 
 ## For BUYERS (Paying for Services)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,11 @@ This directory is split into two parts:
 - `docs/agent-skills.md`
 - `docs/cli-reference.md`
 
+### Examples
+
+- `examples/local-economy/README.md`
+- `examples/business-compute/README.md`
+
 ### Product And Architecture
 
 - `docs/FEATURES.md`


### PR DESCRIPTION
## Summary

  Adds top-level docs pointers for the canonical local examples.

  ## Changes

  Updates:
  - `README.md`
  - `docs/README.md`

  New references added:
  - `examples/local-economy/README.md`
  - `examples/business-compute/README.md`

  ## Why

  This makes the supported examples easier to discover from the main project documentation:
  - the canonical local buyer/seller flow
  - the business-facing paid compute / paid PDF seller example
