### PR TITLE
Fix Gateway balance parsing: select by domain instead of balances[0]

### DIFF
--- a/src/omniclaw/protocols/nanopayments/client.py
+++ b/src/omniclaw/protocols/nanopayments/client.py
@@ -754,7 +754,7 @@ class NanopaymentClient:
         """
         await self.get_supported()
 
-        _caip2_to_circle_domain_id(network)
+        expected_domain = _caip2_to_circle_domain_id(network)
         body: dict[str, Any] = {
             "token": "USDC",
             "sources": [
@@ -789,7 +789,19 @@ class NanopaymentClient:
         formatted_total = "0 USDC"
         formatted_available = "0 USDC"
         if balances:
-            bal = balances[0]
+            depositor_lc = address.lower()
+
+            # Circle may return multiple domains; never assume index 0 is the requested network.
+            by_depositor = [
+                b
+                for b in balances
+                if str(b.get("depositor", "")).lower() == depositor_lc or not b.get("depositor")
+            ]
+            by_domain = [
+                b for b in by_depositor if int(_to_int(b.get("domain", 0))) == expected_domain
+            ]
+            bal = by_domain[0] if by_domain else (by_depositor[0] if by_depositor else balances[0])
+
             # Circle returns "balance" field with string amount, no separate available field
             balance_str = bal.get("balance", "0")
             total = _to_int(balance_str)


### PR DESCRIPTION
﻿## Summary
Fixes a real balance-parsing bug in `NanopaymentClient.check_balance` that can report `0` even when the funded domain has balance.

## Problem
Circle `POST /v1/balances` returns an array across multiple domains. The previous logic effectively relied on the first row (`balances[0]`).

That is unsafe because row order is not guaranteed to match the requested network domain.

Observed case from live testing:
- `domain: 0` first row had `balance: "0"`
- funded row was `domain: 26` with non-zero balance

## User-visible impact
This can cause false negatives in readiness and spending checks:
- `/api/v1/x402/inspect` may return `buyer_ready: false` with "Gateway balance is below the required amount"
- `/api/v1/balance-detail` can show `gateway_balance: 0.00` while on-chain balance is non-zero
- preflight checks may raise insufficient-balance errors unnecessarily

## Fix
In `check_balance`:
1. Map the requested CAIP-2 network to expected Circle domain.
2. Filter rows by depositor.
3. Prefer exact expected-domain match.
4. Fallback to depositor match, then final fallback to first row.

This preserves backward compatibility while removing the incorrect index-0 assumption.

## Why this is correct
The selected balance now aligns with the network being checked, which is the value downstream logic uses for inspect/preflight decisions.
