### PR TITLE
Remove remaining seller-side wording

### DIFF
--- a/src/omniclaw/protocols/nanopayments/types.py
+++ b/src/omniclaw/protocols/nanopayments/types.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any
 
 # =============================================================================
-# PAYMENT REQUIREMENTS (from 402 response / seller side)
+# PAYMENT REQUIREMENTS (from 402 response)
 # =============================================================================
 
 

--- a/src/omniclaw/protocols/x402.py
+++ b/src/omniclaw/protocols/x402.py
@@ -987,7 +987,7 @@ class X402Adapter(ProtocolAdapter):
                 result["reason"] = (
                     "Buyer can create a valid x402 payment payload. "
                     "Direct wallet balance check was skipped; execution still depends on "
-                    "seller-side settlement and on-chain balance."
+                    "the remote payment handler and on-chain balance."
                 )
 
         except Exception as e:


### PR DESCRIPTION
## Summary\n- Remove the last generic seller-side wording from buyer-side x402/nanopayment code comments and messages.\n- Keeps public OmniClaw core focused on buyer/payment-agent infrastructure after the hosted facilitator split.\n\n## Verification\n- uv run ruff check src/omniclaw/protocols/x402.py src/omniclaw/protocols/nanopayments/types.py\n- rg scan for hosted facilitator / seller-side wording\n- git ls-files scan for removed hosted/seller/facilitator modules\n