### PR TITLE
chore: prepare v0.0.8 release

### DIFF
--- a/src/omniclaw/__init__.py
+++ b/src/omniclaw/__init__.py
@@ -141,7 +141,7 @@ from omniclaw.protocols.nanopayments import (
 )
 from omniclaw.trust.gate import TrustGate
 
-__version__ = "0.0.6"
+__version__ = "0.0.8"
 __all__ = [
     # Main Client
     "OmniClaw",


### PR DESCRIPTION
## Summary
- bump OmniClaw runtime version to 0.0.8

## Verification
- uv run python - <<'PY'
import omniclaw
print(omniclaw.__version__)
PY
- uv run ruff check src/omniclaw/__init__.py
- uv run python -m build
- uv run twine check dist/*

After this PR is merged, tag the resulting main commit as v0.0.8 and push the tag before publishing.